### PR TITLE
MacOS -> macOS, Fix hardware sources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ I am a potato who does random things on GitHub to try and improve own skills one
 
 <details><summary>Technical Specifications</summary>
 
-[![OS - macOS 10.13.6](https://img.shields.io/badge/macOS-10.13.6-FFFFFF?style=flat&logo=apple&logoColor=white)](https://en.wikipedia.org/wiki/macOS) [![CPU - Intel Core i7-870](https://img.shields.io/badge/Intel_Core_i7-870-0071c5?style=flat&logo=intel&logoColor=blue)](https://www.intel.com/content/www/us/en/products/sku/41315/intel-core-i7870-processor-8m-cache-2-93-ghz/specifications.html)  [![GPU - ATI Radeon HD 5750](https://img.shields.io/badge/ATI_Radeon_HD-5750-ED1C24?style=flat&logo=amd&logoColor=red)](https://www.techpowerup.com/gpu-specs/radeon-hd-5750.c249)
+[![OS - macOS 10.13.6](https://img.shields.io/badge/macOS-10.13.6-FFFFFF?style=flat&logo=apple&logoColor=black)](https://en.wikipedia.org/wiki/macOS) [![CPU - Intel Core i7-870](https://img.shields.io/badge/Intel_Core_i7-870-0071c5?style=flat&logo=intel&logoColor=blue)](https://www.intel.com/content/www/us/en/products/sku/41315/intel-core-i7870-processor-8m-cache-2-93-ghz/specifications.html)  [![GPU - ATI Radeon HD 5750](https://img.shields.io/badge/ATI_Radeon_HD-5750-ED1C24?style=flat&logo=amd&logoColor=red)](https://www.techpowerup.com/gpu-specs/radeon-hd-5750.c249)
 
 [![iMac (27-inch, Mid 2010)](https://img.shields.io/badge/iMac-(27_Inch,_Mid_2010)-FFFFFF?style=flat&logo=apple&logoColor=black)](https://support.apple.com/kb/sp695?locale=en_US)
 [![Mobile - Samsung Galaxy Note 9](https://img.shields.io/badge/Samsung_Galaxy-Note_9-0c4da2?style=flat&logo=samsung&logoColor=white)](https://en.wikipedia.org/wiki/Samsung_Galaxy_Note_9)

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 I am a potato who does random things on GitHub to try and improve own skills one at a time, and I mainly contribute and suggest ideas to other projects if I feel like it.
 
 - 🔭 I am a official moderator for the [Fabulously Optimized](https://fabulously-optimized.github.io/discord) modpack,
-- 🍎 I daily-drive MacOS on my computer because I am satisified with it and don't need a ridiculous windows desktop experience,
+- 🍎 I daily-drive macOS on my computer because I am satisified with it and don't need a ridiculous windows desktop experience,
 - 📝 Sometimes I like to write articles based on my opinions on topics from time-to-time whenever i feel like it.
 
-<sub><sup><sup>stole this readme from [Kichura](https://github.com/Kichura) who stole it from [kennytv](https://github.com/kennytv) and [triphora](https://github.com/triphora) just to make my own one out of it. thank you!</sup></sup></sup>
+<sub><sup><sup>stole this readme from [Kichura](https://github.com/Kichura) who also stole it from [kennytv](https://github.com/kennytv) and [triphora](https://github.com/triphora) just to make my own one out of it. thank you!</sup></sup></sup>
 
 <details><summary>Technical Specifications</summary>
 
-[![OS - MacOS 10.13.6](https://img.shields.io/badge/MacOS-10.13.6-FFFFFF?style=flat&logo=apple&logoColor=white)](https://en.wikipedia.org/wiki/MacOS) [![CPU - Intel Core i7](https://img.shields.io/badge/Intel_Core-i7--870-blue?style=flat&logo=intel&logoColor=white)](https://www.intel.co.uk/content/www/uk/en/products/sku/41315/intel-core-i7870-processor-8m-cache-2-93-ghz/specifications.html) [![GPU - ATI Radeon HD 5750](https://img.shields.io/badge/ATI_Radeon_HD-5750-ED1C24?style=flat&logo=amd&logoColor=white)](https://www.techpowerup.com/gpu-specs/radeon-hd-5750.c249)
+[![OS - macOS 10.13.6](https://img.shields.io/badge/macOS-10.13.6-FFFFFF?style=flat&logo=apple&logoColor=white)](https://en.wikipedia.org/wiki/macOS) [![CPU - Intel Core i7-870](https://img.shields.io/badge/Intel_Core_i7-870-0071c5?style=flat&logo=intel&logoColor=blue)](https://www.intel.com/content/www/us/en/products/sku/41315/intel-core-i7870-processor-8m-cache-2-93-ghz/specifications.html)  [![GPU - ATI Radeon HD 5750](https://img.shields.io/badge/ATI_Radeon_HD-5750-ED1C24?style=flat&logo=amd&logoColor=red)](https://www.techpowerup.com/gpu-specs/radeon-hd-5750.c249)
 
-[![iMac - 27-inch, Mid 2010)](https://img.shields.io/badge/iMac-FFFFFF?style=flat&logo=apple&logoColor=black)](https://support.apple.com/kb/sp695?locale=en_US)
-[![Mobile - Samsung Galaxy Note 9](https://img.shields.io/badge/Samsung_Galaxy-Note_9-FFFFFF?style=flat&logo=samsung)](https://en.wikipedia.org/wiki/Samsung_Galaxy_Note_9)
+[![iMac (27-inch, Mid 2010)](https://img.shields.io/badge/iMac-(27_Inch,_Mid_2010)-FFFFFF?style=flat&logo=apple&logoColor=black)](https://support.apple.com/kb/sp695?locale=en_US)
+[![Mobile - Samsung Galaxy Note 9](https://img.shields.io/badge/Samsung_Galaxy-Note_9-0c4da2?style=flat&logo=samsung&logoColor=white)](https://en.wikipedia.org/wiki/Samsung_Galaxy_Note_9)


### PR DESCRIPTION
Sets the "MacOS" text to "macOS" as that is what apple uses in it's own term,
Adds the word "also" to the stole part because it sounds a bit better,
Corrects one of the apple logo to also be black instead of white for consistency,
and resolves hardware sources for proper referencing.